### PR TITLE
Add file encoding

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 require_dependency 'redmine_issue_field_visibility'
 
 Redmine::Plugin.register :redmine_issue_field_visibility do


### PR DESCRIPTION
Set file encoding as UTF-8 to fix "invalid byte sequence in US-ASCII" error.
